### PR TITLE
无法正确加载正在开发的插件

### DIFF
--- a/lib/plugin/package.coffee
+++ b/lib/plugin/package.coffee
@@ -175,11 +175,6 @@ exports.list = ()->
 
 #用于执行某个插件一次
 exports.run = (pluginName, cb)->
-  file = _path.join _utils.globalPluginDirectory(), pluginName
-  if not _fs.existsSync file
-    console.log "Plugin #{pluginName} is not found."
-    return cb null
-
   options = _utils.config.plugins[pluginName] || {}
   #注册插件
   _plugin.registerPlugin pluginName, options


### PR DESCRIPTION
无法正确加载正在开发的插件，　判断文件的时候没有去读取配置里面`plugin`的`source`
而且插件文件的存在　在`_plugin.registerPlugin`已经做过一次判断．不需要提前在判断一次
